### PR TITLE
Proposed fix for #319

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -86,11 +86,11 @@ else
     IFS="[,]" read -ra remote_fields <<< "${branch_fields[1]}"
     upstream="${remote_fields[0]}"
     for remote_field in "${remote_fields[@]}"; do
-      if [[ "$remote_field" == *"ahead "* ]]; then
+      if [[ "$remote_field" == "ahead "* ]]; then
         num_ahead=${remote_field:6}
         ahead="_AHEAD_${num_ahead}"
       fi
-      if [[ "$remote_field" == *"behind "* ]]; then
+      if [[ "$remote_field" == " behind "* ]]; then
         num_behind=${remote_field:7}
         behind="_BEHIND_${num_behind# }"
       fi

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -86,11 +86,11 @@ else
     IFS="[,]" read -ra remote_fields <<< "${branch_fields[1]}"
     upstream="${remote_fields[0]}"
     for remote_field in "${remote_fields[@]}"; do
-      if [[ "$remote_field" == *ahead* ]]; then
+      if [[ "$remote_field" == *"ahead "* ]]; then
         num_ahead=${remote_field:6}
         ahead="_AHEAD_${num_ahead}"
       fi
-      if [[ "$remote_field" == *behind* ]]; then
+      if [[ "$remote_field" == *"behind "* ]]; then
         num_behind=${remote_field:7}
         behind="_BEHIND_${num_behind# }"
       fi

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -90,7 +90,7 @@ else
         num_ahead=${remote_field:6}
         ahead="_AHEAD_${num_ahead}"
       fi
-      if [[ "$remote_field" == " behind "* ]]; then
+      if [[ "$remote_field" == *"behind "* ]]; then
         num_behind=${remote_field:7}
         behind="_BEHIND_${num_behind# }"
       fi

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -90,7 +90,7 @@ else
         num_ahead=${remote_field:6}
         ahead="_AHEAD_${num_ahead}"
       fi
-      if [[ "$remote_field" == *"behind "* ]]; then
+      if [[ "$remote_field" == "behind "* ]] || [[ "$remote_field" == " behind "* ]]; then
         num_behind=${remote_field:7}
         behind="_BEHIND_${num_behind# }"
       fi


### PR DESCRIPTION
After analyzing the output from

`git status --porcelain --branch`

`## behind...upstream/master [ahead 2, behind 10]`

I think that this is the best fix, with minimal wildcards. What happens is that the string is split on `[,]` and that leaves us with the desired parts:

`ahead 2` and ` behind 10`. Note the leading space in the behind case.

So we should check for 

`if [[ "$remote_field" == "ahead "* ]]; then`

in the ahead case and

`if [[ "$remote_field" == "behind "* ]] || [[ "$remote_field" == " behind "* ]]; then`

in the behind case. 

If we use a full wildcard in front of behind we might get false positives again like in the original.